### PR TITLE
#minor excluded osx files from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# OSX files
+.DS_Store


### PR DESCRIPTION
So that Mac OS files don't get committed in the future by accident